### PR TITLE
Metaobject in object

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,14 @@ TARGET    = src/targetsomstandalone.py
 # BENCHS_INCLUDES = $(shell find Examples/Benchmarks -type d -printf '%p:')
 # BENCHS_INCLUDES = Examples/Benchmarks/Mate/IndividualOperations:Examples/Benchmarks/Mate/Tracing:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/Mate/Immutability:Examples/Benchmarks/Mate/Immutability/Handles:Examples/Benchmarks/Mate/Immutability/DelegationProxies
 # BENCHS_INCLUDES = Examples/Benchmarks/Mate/Immutability/DelegationProxies:Examples/Benchmarks/Mate/Immutability/Handles:Examples/Benchmarks/Mate/Immutability:Examples/Benchmarks/Mate/IndividualOperations:Examples/Benchmarks/Mate/Tracing:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json/:Examples/Benchmarks/Mate/Columnar
-BENCHS_INCLUDES = Examples/Benchmarks/Mate/ImmutableAwf:Examples/Benchmarks/Mate/Immutability/Handles:Examples/Benchmarks/Mate/ImmutableAwf/CD:Examples/Benchmarks/Mate/ImmutableAwf/DeltaBlue
-# BENCHS_INCLUDES = Examples/Benchmarks/Mate/ImmutableAwf:Examples/Benchmarks/Mate/Immutability/Handles:Examples/Benchmarks/CD
 
-FILESYSTEM_INCLUDES = Smalltalk/Collections/Streams:Smalltalk/FileSystem/Core:Smalltalk/FileSystem/Disk:Smalltalk/FileSystem/Streams
+BENCHS_INCLUDES_HANDLES = Examples/Benchmarks/Mate/Immutability/HandlesEnvInObj
+BENCHS_INCLUDES_MATE_AWF = $(shell find core-lib/Examples/Benchmarks/Mate/ImmutableAwf -type d -printf '%p:')
+BENCHS_INCLUDES = ${BENCHS_INCLUDES_HANDLES}:${BENCHS_INCLUDES_MATE_AWF}
 
 BASE_INCLUDES = Smalltalk:Smalltalk/Mate/:Smalltalk/Mate/MOP
+FILESYSTEM_INCLUDES = Smalltalk/Collections/Streams:Smalltalk/FileSystem/Core:Smalltalk/FileSystem/Disk:Smalltalk/FileSystem/Streams
+
 
 ifdef JIT
 	JIT_ARGS = -Ojit
@@ -37,7 +39,7 @@ ifdef LOG
 endif
 
 ifndef SIZE
-	SIZE=10 10 10
+	SIZE=1 1 1
 endif
 
 all: compile

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,10 @@ COMMAND   = ./som.sh
 TARGET    = src/targetsomstandalone.py
 
 # BENCHS_INCLUDES = $(shell find Examples/Benchmarks -type d -printf '%p:')
-#BENCHS_INCLUDES = Examples/Benchmarks/Mate/IndividualOperations:Examples/Benchmarks/Mate/Tracing:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/Mate/Immutability:Examples/Benchmarks/Mate/Immutability/Handles:Examples/Benchmarks/Mate/Immutability/DelegationProxies
-BENCHS_INCLUDES = Examples/Benchmarks/Mate/Immutability/DelegationProxies:Examples/Benchmarks/Mate/Immutability/Handles:Examples/Benchmarks/Mate/Immutability:Examples/Benchmarks/Mate/IndividualOperations:Examples/Benchmarks/Mate/Tracing:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json/:Examples/Benchmarks/Mate/Columnar
+# BENCHS_INCLUDES = Examples/Benchmarks/Mate/IndividualOperations:Examples/Benchmarks/Mate/Tracing:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/Mate/Immutability:Examples/Benchmarks/Mate/Immutability/Handles:Examples/Benchmarks/Mate/Immutability/DelegationProxies
+# BENCHS_INCLUDES = Examples/Benchmarks/Mate/Immutability/DelegationProxies:Examples/Benchmarks/Mate/Immutability/Handles:Examples/Benchmarks/Mate/Immutability:Examples/Benchmarks/Mate/IndividualOperations:Examples/Benchmarks/Mate/Tracing:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json/:Examples/Benchmarks/Mate/Columnar
+BENCHS_INCLUDES = Examples/Benchmarks/Mate/ImmutableAwf:Examples/Benchmarks/Mate/Immutability/Handles:Examples/Benchmarks/Mate/ImmutableAwf/CD:Examples/Benchmarks/Mate/ImmutableAwf/DeltaBlue
+# BENCHS_INCLUDES = Examples/Benchmarks/Mate/ImmutableAwf:Examples/Benchmarks/Mate/Immutability/Handles:Examples/Benchmarks/CD
 
 FILESYSTEM_INCLUDES = Smalltalk/Collections/Streams:Smalltalk/FileSystem/Core:Smalltalk/FileSystem/Disk:Smalltalk/FileSystem/Streams
 
@@ -35,7 +37,7 @@ ifdef LOG
 endif
 
 ifndef SIZE
-	SIZE=10 10 100
+	SIZE=10 10 10
 endif
 
 all: compile
@@ -152,6 +154,9 @@ matevm-ss:
 
 matevm-r:
 	make BENCH=ReadonlySumKeysEnvInObj.som matevm-bench
+
+mate-d:
+	make BENCH=DelegationProxiesSumKeys.som mate-bench
 
 mate-r:
 	make BENCH=ReadonlySumKeysEnvInObj.som mate-bench

--- a/src/mate/interpreter/invokable.py
+++ b/src/mate/interpreter/invokable.py
@@ -6,7 +6,8 @@ from som.vmobjects.array         import Array
 import som.vm.universe
 from mate.interpreter.nodes.lookup import UninitializedMateLookUpNode
 from rpython.rlib.jit import we_are_jitted
-from som.vmobjects.context       import Context
+from rpython.rlib.debug import attach_gdb
+from som.vmobjects.context import Context
 from som.vm.globals import trueObject, falseObject
 
 class MateInvokablePrimitive(ExpressionNode):
@@ -58,7 +59,7 @@ class MateInvokable(MateNode):
             # El mate enviroment no define el methodo correspondiente a este nodo
             return self._som_node.invoke(receiver, arguments, call_frame)
 
-        sm_args = method.invoke_to_mate(receiver, [self._som_node.get_method(), Array.from_objects([environment, trueObject] + arguments)], call_frame)
+        sm_args = method.invoke_to_mate(receiver, [self._som_node.get_method().get_signature(), Array.from_objects([environment, trueObject, receiver] + arguments)], call_frame)
         assert(isinstance(sm_args, Array))
         new_args = sm_args.as_argument_array()
 
@@ -69,10 +70,10 @@ class MateInvokable(MateNode):
             else:
                 environment = None
 
-            return self._som_node.invoke_from_mate(receiver, new_args[2:], call_frame, environment)
+            return self._som_node.invoke_from_mate(new_args[2], new_args[3:], call_frame, environment)
         else:
             # Sigo en meta level
-            return self._som_node.invoke_to_mate(receiver, new_args[2:], call_frame)
+            return self._som_node.invoke_to_mate(new_args[2], new_args[3:], call_frame)
 
     def reflective_op(self):
         return ReflectiveOp.MessageActivation

--- a/src/mate/interpreter/nodes/field_node.py
+++ b/src/mate/interpreter/nodes/field_node.py
@@ -1,8 +1,25 @@
 from mate.interpreter.nodes.mate_node import MateNode
 from mate.vm.constants import ReflectiveOp
 from som.vmobjects.integer import Integer
+from som.vmobjects.object import Object
 
-class MateFieldReadNode(MateNode):
+
+class MateFieldNode(MateNode):
+
+    def execute(self, frame):
+
+        value = None
+        receiver = self._som_node.get_receiver(frame)
+
+        if not frame.meta_level():
+            value = self.do_mate_semantics(frame, receiver)
+
+        if value is None:
+            return self._som_node.execute_with_receiver(frame, receiver)
+        else:
+            return value
+
+class MateFieldReadNode(MateFieldNode):
 
     def get_meta_args(self, frame):
         return [Integer(self._som_node.field_idx() + 1)]

--- a/src/mate/interpreter/nodes/mate_node.py
+++ b/src/mate/interpreter/nodes/mate_node.py
@@ -27,7 +27,8 @@ class MateNode(ExpressionNode):
 
         value = None
         if not frame.meta_level():
-            value = self.do_mate_semantics(frame)
+            receiver = frame.get_self()
+            value = self.do_mate_semantics(frame, receiver)
 
         if value is None:
             return self._som_node.execute(frame)
@@ -37,11 +38,17 @@ class MateNode(ExpressionNode):
     def _lookup_meta_invokable(self, environment):
         return self._lookup_node.lookup_meta_invokable(environment)
 
-    def do_mate_semantics(self, frame):
+    def do_mate_semantics(self, frame, receiver):
         assert frame is not None
 
-        receiver = frame.get_self()
         environment = frame.get_meta_object_environment() or receiver.get_meta_object_environment()
+
+        # if self.reflective_op() in (1, 17):
+        #     print self
+        #     print self._som_node
+        #     print frame
+        #     print frame._temps_for_inner
+        #     print "%s %s" % (self.reflective_op(), receiver)
 
         # No esta definido o es Nil
         if environment is None or not isinstance(environment, Object):

--- a/src/som/interpreter/nodes/field_node.py
+++ b/src/som/interpreter/nodes/field_node.py
@@ -39,6 +39,11 @@ class FieldReadNode(_AbstractFieldNode):
         _AbstractFieldNode.__init__(self, self_exp, field_idx, source_section)
         self._read = self.adopt_child(create_read(field_idx))
 
+    def execute_with_receiver(self, frame, self_obj):
+        assert isinstance(self_obj, Object)
+
+        return self._read.read(frame, self_obj)
+
     def execute(self, frame):
         self_obj = self._self_exp.execute(frame)
         assert isinstance(self_obj, Object)
@@ -65,6 +70,16 @@ class FieldWriteNode(_AbstractFieldNode):
 
     def value(self, frame):
         return self._value_exp.execute(frame)
+
+    def execute_with_receiver(self, frame, self_obj):
+        value = self._value_exp.execute(frame)
+
+        assert isinstance(self_obj, Object)
+        assert isinstance(value, AbstractObject)
+
+        self._write.write(frame, self_obj, value)
+
+        return value
 
     def execute(self, frame):
         self_obj = self._self_exp.execute(frame)

--- a/src/som/vmobjects/primitive.py
+++ b/src/som/vmobjects/primitive.py
@@ -89,11 +89,11 @@ class MatePrimitive(Primitive):
             # El mate enviroment no define el methodo correspondiente a este nodo
             return inv(self, receiver, arguments, call_frame)
 
-        sm_args = method.invoke_to_mate(receiver, [self, Array.from_objects([environment, trueObject] + arguments)], call_frame)
+        sm_args = method.invoke_to_mate(receiver, [self.get_signature(), Array.from_objects([environment, trueObject, receiver] + arguments)], call_frame)
         assert(isinstance(sm_args, Array))
         new_args = sm_args.as_argument_array()
 
-        return inv(self, receiver, new_args[2:], call_frame)
+        return inv(self, new_args[2], new_args[3:], call_frame)
 
 def empty_primitive(signature_string, universe):
     """ Return an empty primitive with the given signature """


### PR DESCRIPTION
- Faltaba evaluar la expresión del receiver para poder obtener correctamente el meta env en los nodos read/write fields.
- Pasó la signatura en lugar de método en el handler de method activate.
